### PR TITLE
Support for binary ids and rails custom fields

### DIFF
--- a/lib/rating/models/rating/rating.rb
+++ b/lib/rating/models/rating/rating.rb
@@ -64,8 +64,8 @@ module Rating
             #{scope_where_query(resource)}
         ).squish
 
-        values =  [sql, resource.class.base_class.name, resource.id]
-        values += [scopeable.class.base_class.name, scopeable.id] unless scopeable.nil? || unscoped_rating?(resource)
+        values =  [sql, resource.class.base_class.name, resource]
+        values += [scopeable.class.base_class.name, scopeable] unless scopeable.nil? || unscoped_rating?(resource)
 
         execute_sql values
       end


### PR DESCRIPTION
This fixes a problem when you try to use columns that aren't integer or string, also, when you use Rails 6+ Custom Field Types. When you call active model sanitizers, active model converts array of parameters by calling serializers for each model field/column, if you call "id" directly on these models, it will bypass the rails serializers and cast and will try to use the field.to_s as column value, resulting into a wrong value on the reference table.

```
Example 1:
class SampleModel
  # id as binary 4444, but displayed and A-B
end

Example 2:
class SampleModel
   attribute :id, :binary_uuid (displayed as: xxxx-yyyy-zzzz-wwwwwwww but saved as binary hex. Tries to save the xxxx-...)
end

Example 3:
class SampleModel
   attribute :id, :advanced_binary_uuid_with_short_uuid_support (displayed as: 6Y0xqMpcRdnpLwHVFjprkX but saved as binary hex. Tries to save 6Y0x instead of binary hex)
end
```